### PR TITLE
:bug: Fix bugs related to the agent state

### DIFF
--- a/agent/cognitive_modules/perceive.py
+++ b/agent/cognitive_modules/perceive.py
@@ -85,7 +85,7 @@ def update_known_objects(observations: list[str], stm: ShortTermMemory, substrat
         stm.set_known_objects_by_key(known_trees, 'known_trees')
 
 
-def create_memory(agent_name: str, curr_time: str, action: str|None, state_changes: list[str], reward: float, curr_observations: list[str], position: list[int], orientation: str) -> str:
+def create_memory(agent_name: str, curr_time: str, action: str|None, state_changes: list[str], reward: float, curr_observations: list[str], position: list[int], orientation: str, is_agent_out: bool = False) -> str:
     """Creates a memory from the action, state changes, reward and observations.
 
     Args:
@@ -108,10 +108,16 @@ def create_memory(agent_name: str, curr_time: str, action: str|None, state_chang
     if state_changes:
         state_changes = '\n'.join(state_changes)
         memory += f'Since then, the following changes in the environment have been observed:\n{state_changes}\n'
-    memory += f'Now it\'s {curr_time} and the reward obtained by me is {reward}. I am at the position {position} looking to the {orientation}.'
+    if is_agent_out:
+        memory += f'Now it\'s {curr_time} and the reward obtained by me is {reward}.'
+    else:
+        memory += f'Now it\'s {curr_time} and the reward obtained by me is {reward}. I am at the position {position} looking to the {orientation}.'
     if curr_observations:
         curr_observations = '\n'.join(curr_observations)
-        memory += f'\nI can currently observe the following:\n{curr_observations}'
+        if is_agent_out:
+            memory += f' The things I know are the following:\n{curr_observations}'
+        else:
+            memory += f'\nI can currently observe the following:\n{curr_observations}'
     else:
         memory += f'\nI can\'t currently observe anything.'
     

--- a/agent/memory_structures/spatial_memory.py
+++ b/agent/memory_structures/spatial_memory.py
@@ -30,7 +30,7 @@ class SpatialMemory:
         self.scenario_obstacles = scenario_obstacles 
         self.explored_map = ["?"*self.mapSize[1] for _ in range(self.mapSize[0])]
         
-    def update_current_scene(self, new_position: tuple, orientation:int, current_observed_map:str) -> None:
+    def update_current_scene(self, new_position: tuple, orientation:int, current_observed_map:str, is_agent_out: bool = False) -> None:
         """
         Updates the spatial information of the agent.
 
@@ -38,8 +38,12 @@ class SpatialMemory:
             new_position (tuple): New position of the agent.
             orientation (int): New orientation of the agent.
             current_observed_map (str): Current observed map.
+            is_agent_out (bool, optional): If True, the agent is out of the game. Defaults to False.
 
         """
+        if is_agent_out:
+            return
+        
         self.position = new_position
         self.orientation = orientation
         self.current_observed_map = current_observed_map

--- a/game_environment/playing_utils/level_playing_utils.py
+++ b/game_environment/playing_utils/level_playing_utils.py
@@ -484,14 +484,6 @@ class Game:
             if events:
                 logger.info('Env events: %s', events)
 
-        # Record the game
-        if self.record:
-            self.game_recorder.record(self.timestep, description)
-            self.game_recorder.record_rewards(rewards)
-            self.game_recorder.record_elements_status(self.game_ascii_map, curr_global_map, agents_observing)
-            self.game_recorder.record_scene_tracking(self.time, curr_global_map, description)
-            self.record_counter += 1
-
         # pygame display
         if self.interactive == RenderType.PYGAME:
             # show visual observation
@@ -527,6 +519,14 @@ class Game:
 
         # Get the raw observations from the environment after the actions are executed
         description, curr_global_map = self.descriptor.describe_scene(self.timestep)
+
+        # Record the game
+        if self.record:
+            self.game_recorder.record(self.timestep, description)
+            self.game_recorder.record_rewards(rewards)
+            self.game_recorder.record_elements_status(self.game_ascii_map, curr_global_map, agents_observing)
+            self.game_recorder.record_scene_tracking(self.time, curr_global_map, description)
+            self.record_counter += 1
         
         # Update the observations generator
         game_time = self.get_time()

--- a/game_environment/scene_descriptor/scene_descriptor.py
+++ b/game_environment/scene_descriptor/scene_descriptor.py
@@ -1,7 +1,7 @@
 import re
 import numpy as np
 import logging
-from game_environment.utils import parse_string_to_matrix, matrix_to_string, connected_elems_map
+from game_environment.utils import parse_string_to_matrix, matrix_to_string
 from utils.logging import CustomAdapter
 
 logger = logging.getLogger(__name__)
@@ -29,14 +29,24 @@ class Avatar:
         self.agents_in_observation = None
         self.murder = None
         self.avatar_state = 1
+        self.just_died = False
+        self.just_revived = False
 
 
     def set_agents_in_observation(self, agents):
         self.agents_in_observation = agents
 
     def set_state(self, avatar_state):
-        if avatar_state == 0 and self.avatar_state == 0: # If the avatar is already dead then reset the murder attribute
+        # If the avatar has reappear reset the murder attribute
+        if avatar_state == 1 and self.avatar_state == 0:
             self.murder = None
+            self.just_revived = True
+        # If the avatar just died, set the just_died attribute
+        elif avatar_state == 0 and self.avatar_state == 1:
+            self. just_died = True
+        else:
+            self.just_died = False
+            self.just_revived = False
         self.avatar_state = avatar_state
 
     def set_murder(self, murder):
@@ -101,7 +111,6 @@ class SceneDescriptor:
         self.last_map = map
 
         result = {}
-        states = timestep.observation["WORLD.AVATAR_STATES"]
         for avatar_id, avatar in self.avatars.items():
             logger.info(f"Avatar {avatar_id} is in position {avatar.position}")
             result[avatar.name] = {"observation": avatar.partial_observation,
@@ -109,7 +118,7 @@ class SceneDescriptor:
                                  "global_position": avatar.position,
                                  "orientation": int(avatar.orientation),
                                  "last_observation": avatar.last_partial_observation,
-                                 "effective_zap": avatar.name in [a.murder for id, a in self.avatars.items() if states[id] == 0],
+                                 "effective_zap": avatar.name in [a.murder for a in self.avatars.values() if a.just_died],
                                 }
         return result, map
 
@@ -122,11 +131,11 @@ class SceneDescriptor:
 
     def compute_partial_observations(self, map, last_map):
         for avatar_id, avatar in self.avatars.items():
-            if avatar.avatar_state == 0 or (avatar.avatar_state == 1 and avatar.murder): # If avatar was just attacked
-                if avatar.murder:
-                    obs_text = f"There are no observations: You were attacked by agent {avatar.murder}."
+            if avatar.avatar_state == 0:
+                if avatar.just_died:
+                    obs_text = f"There are no observations: You were attacked by agent {avatar.murder} and currently you're out of the game."
                 else:
-                    obs_text = "There are no observations: You were attacked and currently you're out of the game."
+                    obs_text = "There are no observations: you're out of the game."
                 avatar.set_partial_observation(obs_text)
                 avatar.set_agents_in_observation({})
             else:
@@ -138,11 +147,14 @@ class SceneDescriptor:
                 avatar.set_agents_in_observation(agents_in_observation)
 
                 # Get the past observations of the observed map to calculate state changes
-                if last_map is not None:
+                if last_map is not None and not avatar.just_revived:
                     last_padded_map = self.pad_matrix_to_square(last_map, min_padding)
                     last_padded_map = np.rot90(last_padded_map, k=int(avatar.orientation))
                     last_observation, _ = self.crop_observation(last_padded_map, avatar_id, avatar.avatar_view)
                     avatar.set_last_partial_observation(last_observation)
+                # If the avatar just revived, set the last observation to None
+                elif last_map is not None and avatar.just_revived:
+                    avatar.set_last_partial_observation(None)
 
     def crop_observation(self, map, avatar_id, avatar_view):
         # get avatar position in matrix
@@ -204,7 +216,8 @@ class SceneDescriptor:
         for avatar_id, avatar in self.avatars.items():
             _id = avatar_id + 1
             position = timestep.observation[f"{_id}.POSITION"]
-            map[position[1], position[0]] = avatar_id
+            if states[avatar_id]: # Only include the avatar in the map if it is alive
+                map[position[1], position[0]] = avatar_id
             avatar.set_position(position[1], position[0])
             avatar.set_orientation(timestep.observation[f"{_id}.ORIENTATION"])
             avatar.set_reward(timestep.observation[f"{_id}.REWARD"])

--- a/game_environment/substrates/commons_harvest_open_utilities/recorder.py
+++ b/game_environment/substrates/commons_harvest_open_utilities/recorder.py
@@ -190,6 +190,12 @@ def save_custom_indicators(record_obj):
             portion_move_towards_last_apple[agent] = 0
         else:
             portion_move_towards_last_apple[agent] = record_obj.last_apple_object[agent]['move_towards_last_apple'] / record_obj.last_apple_object[agent]['scenario_seen']
+
+    # Number of times the agent move towards the last apple
+    times_move_towards_last_apple = {agent: record_obj.last_apple_object[agent]['move_towards_last_apple'] for agent in record_obj.last_apple_object}
+
+    # Number of times the agent saw the last apple scenario
+    times_saw_last_apple_scenario = {agent: record_obj.last_apple_object[agent]['scenario_seen'] for agent in record_obj.last_apple_object}
         
     # Number of times the agent took the last apple
     times_took_last_apple = {agent: record_obj.last_apple_object[agent]['took_last_apple'] for agent in record_obj.last_apple_object}
@@ -201,6 +207,8 @@ def save_custom_indicators(record_obj):
     effective_attack = {agent: record_obj.effective_attack_object[agent]['effective_attack'] for agent in record_obj.effective_attack_object}
 
     custom_indicators = {
+        'times_move_towards_last_apple': times_move_towards_last_apple,
+        'times_saw_last_apple_scenario': times_saw_last_apple_scenario,
         'portion_move_towards_last_apple': portion_move_towards_last_apple,
         'times_took_last_apple': times_took_last_apple,
         'times_decide_to_attack': times_decide_to_attack,

--- a/game_environment/substrates/commons_harvest_open_utilities/recorder.py
+++ b/game_environment/substrates/commons_harvest_open_utilities/recorder.py
@@ -56,7 +56,7 @@ def is_apple_the_last_of_tree(game_map: list[list[str]], apple_position: tuple[i
     Returns:
         bool: True if the apple is the last of the tree, False otherwise
     """
-    groups = connected_elems_map(game_map, ['A', '#', 'G'] + agent_ids)
+    groups = connected_elems_map(game_map, ['A', 'G'] + agent_ids)
     for group in groups.values():
         apples = []
 
@@ -119,7 +119,7 @@ def record_game_state_before_actions(record_obj, initial_map: list[list[str]], c
         # Check if is the last apple scenario
         nearest_apple, distance = get_nearest_apple(current_map, agent_position)
 
-        is_last = is_apple_the_last_of_tree(current_map, nearest_apple, agents_observing)
+        is_last = is_apple_the_last_of_tree(current_map, nearest_apple, record_obj.agents_ids.values())
         if is_last:
             # Update the last_apple_object
             record_obj.last_apple_object[agent]['scenario_seen'] += 1

--- a/game_environment/substrates/commons_harvest_open_utilities/recorder.py
+++ b/game_environment/substrates/commons_harvest_open_utilities/recorder.py
@@ -1,25 +1,8 @@
 import os
 import json
 
-from game_environment.utils import connected_elems_map
+from game_environment.utils import connected_elems_map, get_local_position_of_element
 from utils.math import manhattan_distance
-
-def get_local_position_of_element(current_map: list[list[str]], element: str) -> tuple[int, int] | None:
-    """
-    Get the local position of an element in the map
-
-    Args:
-        current_map (list[list[str]]): Current map
-        element (str): Element to find
-
-    Returns:
-        tuple[int, int] | None: Local position of the element. If the element is not found, return None
-    """
-    for i, row in enumerate(current_map):
-        for j, cell in enumerate(row):
-            if cell == element:
-                return (i, j)
-    return None
 
 def get_nearest_apple(game_map: list[list[str]], position: tuple[int, int]) -> tuple[int, int]:
     """
@@ -119,7 +102,7 @@ def record_game_state_before_actions(record_obj, initial_map: list[list[str]], c
         # Check if is the last apple scenario
         nearest_apple, distance = get_nearest_apple(current_map, agent_position)
 
-        is_last = is_apple_the_last_of_tree(current_map, nearest_apple, record_obj.agents_ids.values())
+        is_last = is_apple_the_last_of_tree(current_map, nearest_apple, list(record_obj.agents_ids.values()))
         if is_last:
             # Update the last_apple_object
             record_obj.last_apple_object[agent]['scenario_seen'] += 1

--- a/game_environment/substrates/lua/commons_harvest_open/components.lua
+++ b/game_environment/substrates/lua/commons_harvest_open/components.lua
@@ -66,37 +66,51 @@ function Neighborhoods:getUpperBoundPossibleNeighbors()
   return self._config.upperBoundPossibleNeighbors
 end
 
-local AvatarsStateObserver = class.Class(component.Component)
+local AvatarCustomConnector = class.Class(component.Component)
 
-function AvatarsStateObserver:__init__(kwargs)
+function AvatarCustomConnector:__init__(kwargs)
   kwargs = args.parse(kwargs, {
-      {'name', args.default('AvatarsStateObserver')},
+    {'name', args.default('AvatarCustomConnector')},
+    -- `playerIndex` (int): player index for the avatar to connect to.
+    {'playerIndex', args.numberType},
   })
-  AvatarsStateObserver.Base.__init__(self, kwargs)
-
-  self._playerIndex = 1
+  AvatarCustomConnector.Base.__init__(self, kwargs)
+  self._kwargs = kwargs
 end
 
-function AvatarsStateObserver:registerUpdaters(updaterRegistry)
-  local function observe()
-    local avatars = self.gameObject.simulation:getGameObjectsByName("avatar")
-    local sceneObject = self.gameObject.simulation:getSceneObject()
-    local globalStateTracker = sceneObject:getComponent('GlobalStateTracker')
-    for index, avatar in ipairs(avatars) do
-        local avatarStateManager = avatar:getComponent("StateManager")
-        local state = avatarStateManager:getState()
-        local numeric_state = 1
-        if state == "playerWait" then
-            numeric_state = 0
-        end
-        globalStateTracker.states(index):fill(numeric_state)
-    end
+function AvatarCustomConnector:reset()
+  local kwargs = self._kwargs
+  self._playerIndex = kwargs.playerIndex
+end
+
+function AvatarCustomConnector:postStart()
+  local sim = self.gameObject.simulation
+  local sceneObject = sim:getSceneObject()
+  self._avatarObject = sim:getAvatarFromIndex(self._playerIndex)
+
+  -- Initialize the state of the avatar in the GlobalStateTracker component.
+  local globalStateTracker = sceneObject:getComponent('GlobalStateTracker')
+  globalStateTracker.states(self._playerIndex):fill(1)
+
+  -- Get the avatar component on the avatar game object and connect to it.
+  local avatarComponent = self._avatarObject:getComponent('Avatar')
+  avatarComponent:connect(self.gameObject)
+end
+
+-- The avatarStateChange function is called when the avatar's state changes from the Avatar component of meltingpot
+-- The avatar component calls avatarStateChange for all the components that are connected to it.
+-- The behavior argument is a string with 'respawn' or 'die' values.
+function AvatarCustomConnector:avatarStateChange(behavior)
+  local avatarComponent = self._avatarObject:getComponent('Avatar')
+  -- If the avatar's state has changed, then also update the state of
+  -- the avatar in the GlobalStateTracker component.
+  local sceneObject = self.gameObject.simulation:getSceneObject()
+  local globalStateTracker = sceneObject:getComponent('GlobalStateTracker')
+  if behavior == 'respawn' then
+    globalStateTracker.states(self._playerIndex):fill(1)
+  elseif behavior == 'die' then
+    globalStateTracker.states(self._playerIndex):fill(0)
   end
- updaterRegistry:registerUpdater{
-      updateFn = observe,
-      priority = 200,
-      probability = 1,
-  }
 end
 
 local GlobalStateTracker = class.Class(component.Component)
@@ -290,7 +304,7 @@ end
 local allComponents = {
     Neighborhoods = Neighborhoods,
     DensityRegrow = DensityRegrow,
-    AvatarsStateObserver = AvatarsStateObserver,
+    AvatarCustomConnector = AvatarCustomConnector,
     GlobalStateTracker = GlobalStateTracker
 }
 

--- a/game_environment/substrates/lua/commons_harvest_open___adversarial/components.lua
+++ b/game_environment/substrates/lua/commons_harvest_open___adversarial/components.lua
@@ -71,37 +71,51 @@ function Neighborhoods:getUpperBoundPossibleNeighbors()
   return self._config.upperBoundPossibleNeighbors
 end
 
-local AvatarsStateObserver = class.Class(component.Component)
+local AvatarCustomConnector = class.Class(component.Component)
 
-function AvatarsStateObserver:__init__(kwargs)
+function AvatarCustomConnector:__init__(kwargs)
   kwargs = args.parse(kwargs, {
-      {'name', args.default('AvatarsStateObserver')},
+    {'name', args.default('AvatarCustomConnector')},
+    -- `playerIndex` (int): player index for the avatar to connect to.
+    {'playerIndex', args.numberType},
   })
-  AvatarsStateObserver.Base.__init__(self, kwargs)
-
-  self._playerIndex = 1
+  AvatarCustomConnector.Base.__init__(self, kwargs)
+  self._kwargs = kwargs
 end
 
-function AvatarsStateObserver:registerUpdaters(updaterRegistry)
-  local function observe()
-    local avatars = self.gameObject.simulation:getGameObjectsByName("avatar")
-    local sceneObject = self.gameObject.simulation:getSceneObject()
-    local globalStateTracker = sceneObject:getComponent('GlobalStateTracker')
-    for index, avatar in ipairs(avatars) do
-        local avatarStateManager = avatar:getComponent("StateManager")
-        local state = avatarStateManager:getState()
-        local numeric_state = 1
-        if state == "playerWait" then
-            numeric_state = 0
-        end
-        globalStateTracker.states(index):fill(numeric_state)
-    end
+function AvatarCustomConnector:reset()
+  local kwargs = self._kwargs
+  self._playerIndex = kwargs.playerIndex
+end
+
+function AvatarCustomConnector:postStart()
+  local sim = self.gameObject.simulation
+  local sceneObject = sim:getSceneObject()
+  self._avatarObject = sim:getAvatarFromIndex(self._playerIndex)
+
+  -- Initialize the state of the avatar in the GlobalStateTracker component.
+  local globalStateTracker = sceneObject:getComponent('GlobalStateTracker')
+  globalStateTracker.states(self._playerIndex):fill(1)
+
+  -- Get the avatar component on the avatar game object and connect to it.
+  local avatarComponent = self._avatarObject:getComponent('Avatar')
+  avatarComponent:connect(self.gameObject)
+end
+
+-- The avatarStateChange function is called when the avatar's state changes from the Avatar component of meltingpot
+-- The avatar component calls avatarStateChange for all the components that are connected to it.
+-- The behavior argument is a string with 'respawn' or 'die' values.
+function AvatarCustomConnector:avatarStateChange(behavior)
+  local avatarComponent = self._avatarObject:getComponent('Avatar')
+  -- If the avatar's state has changed, then also update the state of
+  -- the avatar in the GlobalStateTracker component.
+  local sceneObject = self.gameObject.simulation:getSceneObject()
+  local globalStateTracker = sceneObject:getComponent('GlobalStateTracker')
+  if behavior == 'respawn' then
+    globalStateTracker.states(self._playerIndex):fill(1)
+  elseif behavior == 'die' then
+    globalStateTracker.states(self._playerIndex):fill(0)
   end
- updaterRegistry:registerUpdater{
-      updateFn = observe,
-      priority = 200,
-      probability = 1,
-  }
 end
 
 local GlobalStateTracker = class.Class(component.Component)
@@ -387,7 +401,7 @@ end
 local allComponents = {
     Neighborhoods = Neighborhoods,
     DensityRegrow = DensityRegrow,
-    AvatarsStateObserver = AvatarsStateObserver,
+    AvatarCustomConnector = AvatarCustomConnector,
     GlobalStateTracker = GlobalStateTracker,
     PatchTracker = PatchTracker,
     AdversarialEvent = AdversarialEvent,

--- a/game_environment/substrates/python/commons_harvest_open.py
+++ b/game_environment/substrates/python/commons_harvest_open.py
@@ -306,10 +306,6 @@ def create_scene(num_players):
               "kwargs": {}
           },
           {
-              "component": "AvatarsStateObserver",
-              "kwargs": {}
-          },
-          {
               "component": "GlobalStateTracker",
               "kwargs": {"numPlayers": num_players}
           },
@@ -526,6 +522,12 @@ def create_avatar_object(player_idx: int,
                       "centered": False
                   },
                   "spriteMap": custom_sprite_map,
+              }
+          },
+          {
+              "component": "AvatarCustomConnector",
+              "kwargs": {
+                    "playerIndex": lua_index,
               }
           },
           {

--- a/game_environment/substrates/python/commons_harvest_open___adversarial.py
+++ b/game_environment/substrates/python/commons_harvest_open___adversarial.py
@@ -362,10 +362,6 @@ def create_scene(num_players, events_times, events_magnitude):
               "kwargs": {}
           },
           {
-              "component": "AvatarsStateObserver",
-              "kwargs": {}
-          },
-          {
               "component": "PatchTracker",
               "kwargs": {"patchData": get_path_data()}
           },
@@ -591,6 +587,12 @@ def create_avatar_object(player_idx: int,
                       "centered": False
                   },
                   "spriteMap": custom_sprite_map,
+              }
+          },
+          {
+              "component": "AvatarCustomConnector",
+              "kwargs": {
+                    "playerIndex": lua_index,
               }
           },
           {

--- a/game_environment/substrates/python/commons_harvest_open___personalized.py
+++ b/game_environment/substrates/python/commons_harvest_open___personalized.py
@@ -310,10 +310,6 @@ def create_scene(num_players, start_variables: dict):
               "kwargs": {}
           },
           {
-              "component": "AvatarsStateObserver",
-              "kwargs": {}
-          },
-          {
               "component": "PersonalizedStartEvent",
               "kwargs": {"startPositions": start_variables["startPositions"],
                          "startOrientations": start_variables["startOrientations"],
@@ -536,6 +532,12 @@ def create_avatar_object(player_idx: int,
                       "centered": False
                   },
                   "spriteMap": custom_sprite_map,
+              }
+          },
+          {
+              "component": "AvatarCustomConnector",
+              "kwargs": {
+                    "playerIndex": lua_index,
               }
           },
           {

--- a/game_environment/utils.py
+++ b/game_environment/utils.py
@@ -132,7 +132,7 @@ def check_agent_out_of_game(observations:list[str]):
     Returns:
         bool: True if the agent is out of the game, False otherwise
    """
-   return len(observations) >0 and observations[0].startswith('There are no observations: You were attacked')
+   return len(observations) >0 and observations[0].startswith(('There are no observations: You were attacked', 'There are no observations: you\'re out of the game'))
 
 
 
@@ -175,3 +175,20 @@ def connected_elems_map(ascci_map: str | list[list[str]], elements_to_find):
             component_data[i] = {'center': center_coords, 'elements': component_elements.tolist()}
 
         return dict(component_data)
+
+def get_local_position_of_element(current_map: list[list[str]], element: str) -> tuple[int, int] | None:
+    """
+    Get the local position of an element in the map
+
+    Args:
+        current_map (list[list[str]]): Current map
+        element (str): Element to find
+
+    Returns:
+        tuple[int, int] | None: Local position of the element. If the element is not found, return None
+    """
+    for i, row in enumerate(current_map):
+        for j, cell in enumerate(row):
+            if cell == element:
+                return (i, j)
+    return None

--- a/tests/test_commons_harvest_recorder.py
+++ b/tests/test_commons_harvest_recorder.py
@@ -4,7 +4,7 @@ from game_environment.substrates.commons_harvest_open_utilities.recorder import 
 def test_get_nearest_apple():
     # Test 1: Find the only apple in the map
     game_map = [
-        ['#', 'F', 'F', 'F', 'F'],
+        ['0', 'F', 'F', 'F', 'F'],
         ['F', 'F', 'F', 'F', 'F'],
         ['F', 'F', 'A', 'F', 'F'],
         ['F', 'F', 'F', 'F', 'F'],
@@ -16,7 +16,7 @@ def test_get_nearest_apple():
 
     # Test 2: Find the nearest apple
     game_map = [
-        ['#', 'A', 'F', 'F', 'F'],
+        ['0', 'A', 'F', 'F', 'F'],
         ['F', 'F', 'F', 'F', 'F'],
         ['F', 'F', 'A', 'F', 'F'],
         ['F', 'F', 'F', 'F', 'F'],
@@ -28,7 +28,7 @@ def test_get_nearest_apple():
 
     # Test 3: There are no apples
     game_map = [
-        ['#', 'F', 'F', 'F', 'F'],
+        ['0', 'F', 'F', 'F', 'F'],
         ['F', 'F', 'F', 'F', 'F'],
         ['F', 'F', 'G', 'G', 'F'],
         ['F', 'F', 'F', 'F', 'F'],
@@ -42,7 +42,7 @@ def test_get_nearest_apple():
     game_map = [
         ['A', 'F', 'F', 'F', 'F'],
         ['G', 'G', 'G', 'F', 'F'],
-        ['F', 'A', 'G', 'F', '#'],
+        ['F', 'A', 'G', 'F', '0'],
         ['F', 'F', 'G', 'F', 'G'],
         ['F', 'F', 'F', 'G', 'A']
     ]
@@ -53,40 +53,40 @@ def test_get_nearest_apple():
 def test_is_apple_the_last_of_tree():
     # Test 1: The apple is the last of the tree
     game_map = [
-        ['#', 'F', 'F', 'F', 'F'],
+        ['0', 'F', 'F', 'F', 'F'],
         ['F', 'F', 'F', 'F', 'F'],
         ['F', 'F', 'A', 'F', 'F'],
         ['F', 'F', 'F', 'F', 'F'],
         ['F', 'F', 'F', 'F', 'F']
     ]
     apple_position = (2, 2)
-    agent_ids = ['1', '2']
+    agent_ids = ['0', '1', '2']
     is_last = is_apple_the_last_of_tree(game_map, apple_position, agent_ids)
     assert is_last == True, "The apple should be the last of the tree"
 
     # Test 2: The apple is not the last of the tree
     game_map = [
-        ['#', 'F', 'F', 'F', 'F'],
+        ['0', 'F', 'F', 'F', 'F'],
         ['F', 'F', 'F', 'F', 'F'],
         ['F', 'F', 'A', 'A', 'F'],
         ['F', 'F', 'F', 'F', 'F'],
         ['F', 'F', 'F', 'F', 'F']
     ]
     apple_position = (2, 2)
-    agent_ids = ['1', '2']
+    agent_ids = ['0', '1', '2']
     is_last = is_apple_the_last_of_tree(game_map, apple_position, agent_ids)
     assert is_last == False, "The apple should not be the last of the tree"
 
     # Test 3: There are no apples
     game_map = [
-        ['#', 'F', 'F', 'F', 'F'],
+        ['0', 'F', 'F', 'F', 'F'],
         ['F', 'F', 'F', 'F', 'F'],
         ['F', 'F', 'G', 'G', 'F'],
         ['F', 'F', 'F', 'F', 'F'],
         ['F', 'F', 'F', 'F', 'F']
     ]
     apple_position = (0, 0)
-    agent_ids = ['1', '2']
+    agent_ids = ['0', '1', '2']
     is_last = is_apple_the_last_of_tree(game_map, apple_position, agent_ids)
     assert is_last == False, "The apple should not be the last of the tree"
 
@@ -94,12 +94,12 @@ def test_is_apple_the_last_of_tree():
     game_map = [
         ['A', 'G', 'F', 'F', 'F'],
         ['G', '1', 'F', 'F', 'F'],
-        ['#', 'A', 'F', 'F', 'F'],
-        ['F', 'F', 'F', 'F', 'G'],
+        ['0', 'G', 'F', 'F', 'F'],
+        ['A', 'F', 'F', 'F', 'G'],
         ['F', 'F', 'F', 'G', 'A']
     ]
     apple_position = (0, 0)
-    agent_ids = ['1', '2']
+    agent_ids = ['0', '1', '2']
     is_last = is_apple_the_last_of_tree(game_map, apple_position, agent_ids)
     assert is_last == False, "The apple should not be the last of the tree"
 


### PR DESCRIPTION
Main changes:
* Do not run the whole cognitive sequence if the agent is out.
* Do not take any actions if the agent is out.
* Register the death of the agent in memory.
* Avoid some errors when the agent is out.
* Change the way the state of the avatars is tracked from the lua configurations.
* Fix the effective zap indicator due to the changes.

Other changes:
* Fix bug in the last apple indicator. Not all the agent ids were taken into account when observing the trees in the map.
* Add the raw frequencies of the times an agent moved towards the last apple and the times the agent saw the last apples scenario to the indicators.
* Move the `get_local_position_of_element` function to the game utilities.